### PR TITLE
Added iter_mut method to Iterable trait

### DIFF
--- a/struct_iterable_derive/src/lib.rs
+++ b/struct_iterable_derive/src/lib.rs
@@ -40,6 +40,22 @@ use struct_iterable_internal::Iterable;
 ///     println!("{}: {:?}", field_name, field_value);
 /// }
 /// ```
+///
+/// Or call the `iter_mut` method to modify the fields:
+///
+/// ```
+/// let mut my_instance = MyStruct {
+///     field1: 42,
+///     field2: "Hello, world!".to_string(),
+/// };
+///
+/// for (field_name, field_value) in my_instance.iter_mut() {
+///     if let Some(num) = field_value.downcast_mut::<i32>() {
+///         *num += 1;
+///     }
+/// }
+/// ```
+
 #[proc_macro_derive(Iterable)]
 pub fn derive_iterable(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -61,13 +77,29 @@ pub fn derive_iterable(input: TokenStream) -> TokenStream {
         }
     });
 
+    let fields_iter_mut = fields.iter().map(|field| {
+        let field_ident = &field.ident;
+        let field_name = field_ident.as_ref().unwrap().to_string();
+        quote! {
+            (#field_name, &mut (self.#field_ident) as &mut dyn std::any::Any)
+        }
+    });
+
     let expanded = quote! {
         impl Iterable for #struct_name {
+
             fn iter<'a>(&'a self) -> std::vec::IntoIter<(&'static str, &'a dyn std::any::Any)> {
                 vec![
                     #(#fields_iter),*
                 ].into_iter()
             }
+
+            fn iter_mut<'a>(&'a mut self) -> std::vec::IntoIter<(&'static str, &'a mut dyn std::any::Any)> {
+                vec![
+                    #(#fields_iter_mut),*
+                ].into_iter()
+            }
+
         }
     };
 

--- a/struct_iterable_internal/src/lib.rs
+++ b/struct_iterable_internal/src/lib.rs
@@ -1,9 +1,12 @@
 /// The `Iterable` trait.
 ///
 /// This trait is implemented for structs that derive the `Iterable` proc macro.
-/// It provides the `iter` method which returns an iterator over the struct's fields as tuples, containing the field name as a static string and a reference to the field's value as `dyn Any`.
+/// It provides the `iter` and `iter_mut` methods which return iterators over the struct's 
+/// fields as tuples, containing the field name as a static string and a reference to the field's 
+/// value as `dyn Any`.
 ///
-/// You usually don't need to implement this trait manually, as it is automatically derived when using the `#[derive(Iterable)]` proc macro.
+/// You usually don't need to implement this trait manually, as it is automatically derived when 
+/// using the `#[derive(Iterable)]` proc macro.
 ///
 /// # Example
 ///
@@ -29,7 +32,8 @@
 pub trait Iterable {
     /// Returns an iterator over the struct's fields as tuples.
     ///
-    /// Each tuple contains a field's name as a static string and a reference to the field's value as `dyn Any`.
+    /// Each tuple contains a field's name as a static string and a reference to the field's 
+    /// value as `dyn Any`.
     ///
     /// # Example
     ///
@@ -53,4 +57,34 @@ pub trait Iterable {
     /// }
     /// ```
     fn iter(&self) -> std::vec::IntoIter<(&'static str, &'_ dyn std::any::Any)>;
+
+    /// Returns a mutable iterator over the struct's fields as tuples.
+    ///
+    /// Each tuple contains a field's name as a static string and a mutable reference to the field's 
+    /// value as `dyn Any`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use struct_iterable::Iterable;
+    ///
+    /// #[derive(Iterable)]
+    /// struct MyStruct {
+    ///     field1: i32,
+    ///     field2: String,
+    /// }
+    ///
+    /// let mut my_instance = MyStruct {
+    ///     field1: 42,
+    ///     field2: "Hello, world!".to_string(),
+    /// };
+    ///
+    /// // Iterate over the fields of `my_instance`:
+    /// for (field_name, field_value) in my_instance.iter_mut() {
+    ///     if let Some(num) = field_value.downcast_mut::<i32>() {
+    ///         *num += 1;
+    ///     }
+    /// }
+    /// ```
+    fn iter_mut(&mut self) -> std::vec::IntoIter<(&'static str, &'_ mut dyn std::any::Any)>;
 }


### PR DESCRIPTION
PR for issue #2. This allows users to iterate over mutable references to fields on a struct. Re-created because Github won't let me change the branch of the other PR.